### PR TITLE
Add toString implementation to FingerIdentifier

### DIFF
--- a/src/main/java/com/simprints/libsimprints/FingerIdentifier.java
+++ b/src/main/java/com/simprints/libsimprints/FingerIdentifier.java
@@ -10,5 +10,33 @@ public enum FingerIdentifier {
     LEFT_INDEX_FINGER,
     LEFT_3RD_FINGER,
     LEFT_4TH_FINGER,
-    LEFT_5TH_FINGER
+    LEFT_5TH_FINGER;
+
+    @Override
+    public String toString() {
+        switch (this) {
+            case RIGHT_5TH_FINGER:
+                return "rightFifthFinger";
+            case RIGHT_4TH_FINGER:
+                return "rightFourthFinger";
+            case RIGHT_3RD_FINGER:
+                return "rightThirdFinger";
+            case RIGHT_INDEX_FINGER:
+                return "rightIndexFinger";
+            case RIGHT_THUMB:
+                return "rightThumb";
+            case LEFT_THUMB:
+                return "leftThumb";
+            case LEFT_INDEX_FINGER:
+                return "leftIndexFinger";
+            case LEFT_3RD_FINGER:
+                return "leftThirdFinger";
+            case LEFT_4TH_FINGER:
+                return "leftFourthFinger";
+            case LEFT_5TH_FINGER:
+                return "leftFifthFinger";
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
 }


### PR DESCRIPTION
Add `FingerIdentifier.toString`, which can be used as a specification for how to name CommCare case properties that store fingerprint templates
