### PR TITLE
Confirm identity API fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Gradle
 ```
-implementation 'com.simprints:libsimprints:2023.2.2'
+implementation 'com.simprints:libsimprints:2023.4.1'
 ```
 
 Maven
@@ -17,7 +17,7 @@ Maven
 <dependency>
   <groupId>com.simprints</groupId>
   <artifactId>libsimprints</artifactId>
-  <version>2023.2.2</version>
+  <version>2023.4.1</version>
   <type>pom</type>
 </dependency>
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
     mavenCentral()
 }
 
-project.version = "2023.2.2"
+project.version = "2023.4.1"
 
 android {
     compileSdkVersion 33

--- a/src/main/java/com/simprints/libsimprints/SimHelper.java
+++ b/src/main/java/com/simprints/libsimprints/SimHelper.java
@@ -131,14 +131,11 @@ public class SimHelper {
     /**
      * Sends which GUID was confirmed in a session back to SimprintsId.
      *
-     * @param context      context of the host app.
      * @param sessionId    identifies the identification session.
      * @param selectedGuid the GUID that was confirmed in the host app.
      * @return a new confirm indentity {@link Intent}.
      */
-    public Intent confirmIdentity(@NonNull Context context,
-                                  @NonNull String sessionId,
-                                  @Nullable String selectedGuid) {
+    public Intent confirmIdentity(@NonNull String sessionId, @Nullable String selectedGuid) {
         Intent intent = new Intent(Constants.SIMPRINTS_SELECT_GUID_INTENT);
         intent.putExtra(Constants.SIMPRINTS_PROJECT_ID, projectId);
         intent.putExtra(Constants.SIMPRINTS_SESSION_ID, sessionId);


### PR DESCRIPTION
* An unnecessary context was required in the SimHelper to confirm identity API. This prevents the usage of LibSimprints anywhere outside the UI/view layer.