### PR TITLE
[MS-161] Add biometric data source constant

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
     mavenCentral()
 }
 
-project.version = "2023.4.1"
+project.version = "2024.1.0"
 
 android {
     compileSdkVersion 33

--- a/src/main/java/com/simprints/libsimprints/Constants.java
+++ b/src/main/java/com/simprints/libsimprints/Constants.java
@@ -30,6 +30,7 @@ public class Constants {
 
     // Optional extras
     final public static String SIMPRINTS_CALLING_PACKAGE = "packageName";
+    final public static String SIMPRINTS_BIOMETRIC_DATA_SOURCE = "biometricDataSource";
     final public static String SIMPRINTS_METADATA = "metadata";
 
     // Custom callout parameters for particular integrations: Don't include if not needed


### PR DESCRIPTION
Add a constant for an optional extra that specifies the biometric data source to be used in the request. More info in https://simprints.atlassian.net/browse/MS-161