### PR TITLE
Bump com.android.tools.build:gradle from 8.6.1 to 8.7.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:8.6.1"
+        classpath "com.android.tools.build:gradle:8.7.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.21"
         classpath "io.github.gradle-nexus:publish-plugin:2.0.0"
     }


### PR DESCRIPTION
Bumps com.android.tools.build:gradle from 8.6.1 to 8.7.1.

---
updated-dependencies:
- dependency-name: com.android.tools.build:gradle dependency-type: direct:production update-type: version-update:semver-minor ...